### PR TITLE
Changed the word 'precision' to 'tolerance' in Params.cpp; Comparison…

### DIFF
--- a/Params.cpp
+++ b/Params.cpp
@@ -61,7 +61,7 @@ namespace kernel_validation {
             else {
                 throw std::runtime_error("Should specify a kernels file.");
             }
-            if (vm.count("precision")) {
+            if (vm.count("tolerance")) {
                 tolerance = vm["tolerance"].as<float>();
             }
             if (vm.count("kernel-names")) {


### PR DESCRIPTION
Setting comparison tolerance has been ignored. After this small change it works!?

Signed-off-by: Malte Schirwon <malte.schirwon@mathematik.uni-stuttgart.de>